### PR TITLE
Enabling special characters in steam password

### DIFF
--- a/RehydratedDownpatcher.ahk
+++ b/RehydratedDownpatcher.ahk
@@ -120,7 +120,7 @@ StartDownpatch(Version, SteamUser, SteamPass)
     ;Run depotdownloader
     Run, cmd.exe, %A_ScriptDir%\Assets\ThirdParty\depotdownloader-2.3.6,, procID
     WinWaitActive, % "ahk_pid" procID
-    SendEvent {Raw}dotnet DepotDownloader.dll -app 969990 -depot 969991 -manifest %ManifestID% -username %SteamUser% -password %SteamPass%
+    SendEvent {Raw}dotnet DepotDownloader.dll -app 969990 -depot 969991 -manifest %ManifestID% -username %SteamUser% -password "%SteamPass%"
     Send {Enter}
 
     ;loop and check until download is finished


### PR DESCRIPTION
If your steam password contains certain special characters such as $ will break the depotdownloader command. (Or at least if a $ is the first character in your password).

Made a quick fix by just adding some quotes around the password. Compiled and tested the changes, figured I'd make a PR to fix this change in case anyone else is affected. 